### PR TITLE
Fix travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: python
-python: 3.6
-env:
- - TOX_ENV=pep8
- - TOX_ENV=py27
- - TOX_ENV=py35
+matrix:
+  include:
+    - python: 2.7
+      env: TOX_ENV=py27
+    - python: 3.5
+      env: TOX_ENV=py35
+    - python: 3.6
+      env: TOX_ENV=pep8
 install:
- - pip install tox
+  - pip install tox
 script:
- - tox -e $TOX_ENV
+  - tox -e $TOX_ENV


### PR DESCRIPTION
By globally bumping the python version in travis the py35 tox target
does not found a proper interpreter. So travis config needs to be
changed to specify python version for each tox target.