### PR TITLE
Write dot files using mode 'w' not 'wb'

### DIFF
--- a/osc_placement_tree/utils.py
+++ b/osc_placement_tree/utils.py
@@ -82,7 +82,7 @@ def dump_placement_db_to_dot(placement_client, out_file, hidden_fields=()):
     graph = tree.make_rp_trees(placement_client, drop_fields=DROP_DATA_FIELDS)
     tree.extend_rp_graph_with_consumers(placement_client, graph)
 
-    with open(out_file, "wb") as f:
+    with open(out_file, "w") as f:
         f.write(
             dot.graph_to_dot(
                 graph, field_filter=lambda name: name not in hidden_fields


### PR DESCRIPTION
In python3 writing the dot files fails, excepting bytes, but
the `dot.source` being written is a string, and on disk what
we have is a straight text file.

Changing to simply 'w' ought to work okay for both python2
and python3.